### PR TITLE
add order in get

### DIFF
--- a/server/src/controllers/customers/products.controller.ts
+++ b/server/src/controllers/customers/products.controller.ts
@@ -30,7 +30,9 @@ export const getProducts = async (
 			(parseInt(page as string) - 1) * parseInt(limit as string);
 		const pageLimit = parseInt(limit as string);
 
-		const order = direct ? [['basePrice', direct]] : [];
+		const order = direct
+			? [['basePrice', direct]]
+			: [['createdAt', 'DESC']];
 
 		const filters = {
 			id: id ? Number(id) : undefined,

--- a/server/src/services/customers/product-variants.service.ts
+++ b/server/src/services/customers/product-variants.service.ts
@@ -53,6 +53,7 @@ export const getVariants = async (filters: any, transaction?: Transaction) => {
 	const [rows, count] = await Promise.all([
 		db.productVariants.findAll({
 			where,
+			order: [['createdAt', 'DESC']],
 			include,
 			limit: filters.limit,
 			offset: filters.offset,

--- a/server/src/services/customers/reviews.service.ts
+++ b/server/src/services/customers/reviews.service.ts
@@ -24,6 +24,7 @@ export const createReview = async (
 
 export const getAllReviews = async (transaction?: Transaction) => {
 	return await db.reviews.findAll({
+		order: [['createdAt', 'DESC']],
 		include: [{ model: db.products }],
 		transaction,
 	});
@@ -35,6 +36,7 @@ export const getReviewsByProduct = async (
 ) => {
 	return await db.reviews.findAll({
 		where: { productId },
+		order: [['createdAt', 'DESC']],
 		include: [{ model: db.products }],
 		transaction,
 	});

--- a/server/src/services/customers/wishlists.service.ts
+++ b/server/src/services/customers/wishlists.service.ts
@@ -7,6 +7,7 @@ export const getAllWishlists = async (
 ) => {
 	return await db.wishlists.findAll({
 		where: { customerId },
+		order: [['createdAt', 'DESC']],
 		include: [{ model: db.products }],
 		transaction,
 	});

--- a/server/src/services/managers/admin-logs.service.ts
+++ b/server/src/services/managers/admin-logs.service.ts
@@ -58,6 +58,7 @@ export const getAdminLogs = async (filters: any, transaction?: Transaction) => {
 	const [rows, count] = await Promise.all([
 		db.adminLogs.findAll({
 			where,
+			order: [['createdAt', 'DESC']],
 			include: [
 				{
 					model: db.admins,

--- a/server/src/services/managers/feedbacks.service.ts
+++ b/server/src/services/managers/feedbacks.service.ts
@@ -3,6 +3,7 @@ import { Transaction } from 'sequelize';
 
 export const getAllFeedbacks = async (transaction?: Transaction) => {
 	return await db.feedbacks.findAll({
+		order: [['createdAt', 'DESC']],
 		include: [
 			{ model: db.customers, attributes: { exclude: ['passwordHash'] } },
 		],


### PR DESCRIPTION
## Summary by Sourcery

Enforce consistent default sorting of list endpoints by creation date in descending order, and provide a fallback sort for product listings when no price sort is specified.

Enhancements:
- Add default fallback order by createdAt descending for product listings when no price sort parameter is provided
- Apply default createdAt descending ordering to review, product variant, wishlist, admin log, and feedback list queries